### PR TITLE
Fix empty SCRIPT_NAME with partial match route bug

### DIFF
--- a/lib/http_router.rb
+++ b/lib/http_router.rb
@@ -220,8 +220,14 @@ class HttpRouter
   end
 
   def rewrite_partial_path_info(env, request)
-    env['PATH_INFO'] = "/#{request.path.join('/')}"
-    env['SCRIPT_NAME'] += request.rack_request.path_info[0, request.rack_request.path_info.size - env['PATH_INFO'].size]
+    path_info_before = request.rack_request.path_info.dup
+    if request.path.empty?
+      env['PATH_INFO'] = "/"
+      env['SCRIPT_NAME'] += path_info_before
+    else
+      env['PATH_INFO'] = "/#{request.path.join('/')}"
+      env['SCRIPT_NAME'] += path_info_before[0, path_info_before.size - env['PATH_INFO'].size]
+    end
   end
 
   def rewrite_path_info(env, request)

--- a/test/rack/test_route.rb
+++ b/test/rack/test_route.rb
@@ -36,4 +36,40 @@ class TestRouteExtensions < MiniTest::Unit::TestCase
   def test_raise_error_on_invalid_status
     assert_raises(ArgumentError) { router.get("/index.html").redirect("/", 200) }
   end
+
+  def test_path_info_from_partial_match
+    request_env = nil
+    router do
+      add("/sidekiq*").to { |env| request_env = env; [200, {}, []] }
+    end
+    router.call(Rack::MockRequest.env_for("/sidekiq/queues"))
+    assert_equal('/queues', request_env['PATH_INFO'])
+  end
+
+  def test_script_name_from_partial_match
+    request_env = nil
+    router do
+      add("/sidekiq*").to { |env| request_env = env; [200, {}, []] }
+    end
+    router.call(Rack::MockRequest.env_for("/sidekiq/queues"))
+    assert_equal('/sidekiq', request_env['SCRIPT_NAME'])
+  end
+
+  def test_path_info_from_partial_match_of_single
+    request_env = nil
+    router do
+      add("/sidekiq*").to { |env| request_env = env; [200, {}, []] }
+    end
+    router.call(Rack::MockRequest.env_for("/sidekiq"))
+    assert_equal('/', request_env['PATH_INFO'])
+  end
+
+  def test_script_name_from_partial_match_of_single
+    request_env = nil
+    router do
+      add("/sidekiq*").to { |env| request_env = env; [200, {}, []] }
+    end
+    router.call(Rack::MockRequest.env_for("/sidekiq"))
+    assert_equal('/sidekiq', request_env['SCRIPT_NAME'])
+  end
 end


### PR DESCRIPTION
Why you made the change:

I made this change so that SCRIPT_NAME and PATH_INFO would be set
appropriately in the scenario where a partial match route is used.

How the change addresses the need:

There is an issue with the current version of rewrite_partial_path_info
where it does not set SCRIPT_NAME appropriately. When the request
environments PATH_INFO is set, it causes the request.rack_request.path_info
helper return the updated version, not the original. This is
requst.rack_request.path_info eventually just reads the PATH_INFO value
out of the request environment. As a side effect of this, the original
code would always set the SCRIPT_NAME to "" because it would be slicing
from request.rack_request.path_info[0, 0] in actuality.

This change resolves this issue by first temporarily storing a dup of
the original path_info and using that to determine the end index for the
SCRIPT_NAME. This change also handles setting SCRIPT_NAME correctly for
the somewhat unique but common case of matching the partial match
exactly.

I have added tests for each of these cases as I couldn't find any tests
covering this before.
