### PR TITLE
Add URI encoding for path info

### DIFF
--- a/lib/http_router.rb
+++ b/lib/http_router.rb
@@ -225,7 +225,7 @@ class HttpRouter
       env['PATH_INFO'] = "/"
       env['SCRIPT_NAME'] += path_info_before
     else
-      env['PATH_INFO'] = "/#{request.path.join('/')}"
+      env['PATH_INFO'] = "/#{URI.encode(request.path.join('/'))}"
       env['SCRIPT_NAME'] += path_info_before[0, path_info_before.size - env['PATH_INFO'].size]
     end
   end

--- a/test/rack/test_route.rb
+++ b/test/rack/test_route.rb
@@ -72,4 +72,22 @@ class TestRouteExtensions < MiniTest::Unit::TestCase
     router.call(Rack::MockRequest.env_for("/sidekiq"))
     assert_equal('/sidekiq', request_env['SCRIPT_NAME'])
   end
+
+  def test_path_info_with_encoded_request_path
+    request_env = nil
+    router do
+      add("/sidekiq*").to { |env| request_env = env; [200, {}, []] }
+    end
+    router.call(Rack::MockRequest.env_for("/sidekiq/queues/some%20path"))
+    assert_equal('/queues/some%20path', request_env['PATH_INFO'])
+  end
+
+  def test_script_name_with_encoded_request_path
+    request_env = nil
+    router do
+      add("/sidekiq*").to { |env| request_env = env; [200, {}, []] }
+    end
+    router.call(Rack::MockRequest.env_for("/sidekiq/queues/some%20path"))
+    assert_equal('/sidekiq', request_env['SCRIPT_NAME'])
+  end
 end


### PR DESCRIPTION
I did this because sometimes the request path will be encoded. Since HTTP
router unencodes the path, it loses the ability to correctly calculate the
path info by performing math on the path length. This encodes the path info
since it is used for correctly assigning the script name.
